### PR TITLE
Add batch upload mode for AirTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This app will login to a specific Twitch.tv channel and watch for users entering
 
 Each user that enters this command will be added to an AirTable that can be used to provide auto-completion of Twitch usernames.
 
+Data will be batched up and pushed into AirTable on a configurable interval (default: 5 seconds).  If there is more than one player that entered `!play` during the interval, the data will be inserted as a single row with multiple comma-separated usernames.
+
 ## Installation
 ### Windows
 **Download & double-click to run the pre-compiled version that comes with NodeJS bundled in or run from source using below steps:**

--- a/bot.js
+++ b/bot.js
@@ -22,7 +22,10 @@ else
 	var configFile = './settings.ini';
 var config = ini.parse(fs.readFileSync(configFile, 'utf-8'))
 
-// Airtable
+// Set default value of update interval to 5 seconds if not configured in INI file
+if (!config.airtable.updateIntervalMs) config.airtable.updateIntervalMs = 5000
+
+// Airtable library setup
 var airtableDB = new Airtable({apiKey: config.airtable.apiKey}).base(config.airtable.baseID);
 
 // Setup twitch settings
@@ -37,7 +40,17 @@ const twitchChatSettings = {
 };
 
 
-console.log('App starting...use Ctrl+C to quit')
+console.log('App starting...use Ctrl+C to quit');
+console.log(`AirTable update interval is ${config.airtable.updateIntervalMs} milliseconds`);
+console.log(`Twitch Channel is ${config.twitch.channel}`);
+console.log(`Bot Username is ${config.twitch.username}`)
+
+// We will buffer players in an array and only push this to Airtables every 5 seconds
+var batchedPlayers = [];
+
+// Setup interval for pushing the current batch of players to AirTable
+// Use timeouts that get reset after every update to avoid overlapping/duplicate API calls if things get bogged down
+setTimeout(batchUpdate,config.airtable.updateIntervalMs);
 
 // Create a Twitch Chat client with our options
 const chatClient = new tmi.client(twitchChatSettings);
@@ -71,21 +84,58 @@ function onMessageHandler (target, context, msg, self) {
 
 // Function that will make a REST API call to AirTables to add a player name
 function addPlayer (player) {
-	console.log(`Adding Player ${chalk.bold(player)}`);
+	console.log(`Adding Player ${chalk.bold(player)} to next update batch`);
+	batchedPlayers.push(player);
+	return;
+}
 
-	airtableDB(config.airtable.tableName).create([{"fields": {[config.airtable.fieldName]: player}}], function(err, records) {
-		if (err) {
-			// Error
-			console.error(chalk.red(`AirTable API Error - ${err}`));
-			return;
-		}
+function batchUpdate() {
 
-		// Success
-		records.forEach(function (record) {
-			console.log(`Added ${chalk.bold(record.fields[config.airtable.fieldName])} to AirTable.`);
+	// Only need to push update to AirTables if we have some players pending in the batch queue
+	if (batchedPlayers.length > 0)
+	{
+		// Grab a snapshot of the queue, since it may get changed while we're processing it
+		var currentBatch = batchedPlayers;
+
+		// Build our payload to push to the AirTables API
+		// This is an array where each item in the array is a row that will be inserted
+		// We'll batch things up into a single row where the data is a comma-seprated list of players
+		var updateData = [ { "fields": {[config.airtable.fieldName]: currentBatch.join(',')} } ];
+
+		airtableDB(config.airtable.tableName).create(updateData, function(err, records) {
+			if (err) {
+				// Error
+				console.error(chalk.red(`AirTable API Error - ${err}`));
+				// Schedule next run for next batch
+				setTimeout(batchUpdate,config.airtable.updateIntervalMs);
+				return;
+			}
+
+			// Success		
+			var recordCount = 0;
+			records.forEach(function (record) {
+				console.log(`Added ${chalk.bold(record.fields[config.airtable.fieldName])} to AirTable.`);
+				recordCount += record.fields[config.airtable.fieldName].split(',').length;
+			});
+			console.log(`Successfully added ${recordCount} players to AirTable.`);
+
+			
 		});
-		console.log(`Successfully added ${records.length} players to AirTable.`)
-	});
+		
+
+		// Remove the players from the queue after we fire off the API call
+		var remainingBatch = Array.from(batchedPlayers);
+		currentBatch.forEach(function (player) {
+			var index = remainingBatch.indexOf(player);
+			if (index > -1)	remainingBatch.splice(index,1)
+		})
+		// Update the array with the filtered/cleaned version
+		batchedPlayers = remainingBatch;
+		
+	}
+
+	// Schedule next run for next batch
+	setTimeout(batchUpdate,config.airtable.updateIntervalMs);
 
 	return;
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"main": "bot.js"
 	},
 	"dependencies": {
-		"axios": "^0.21.1",
+		"airtable": "^0.10.1",
 		"chalk": "^4.1.0",
 		"ini": "^2.0.0",
 		"tmi.js": "^1.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twitch-airtable-chatwatch",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"license": "Zlib",
 	"main": "bot.js",
 	"bin": {

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -29,10 +29,12 @@ channel = nightattack
 
 ; "tableName" - AirTable Table to insert records into
 ; "fieldName" - This field in the above table will be populated with the player's twitch Display Name (username)
+; "updateIntervalMs" - How often (in milliseconds) the player list is batched up and pushed into AirTables (e.g. 5000 = 5 seconds). For API rate-limiting.
 
 [airtable]
 apiKey = keyDKkn3md78aQ
 baseID = applk132m1nd7ak
 tableName = ViewersAutoComplete
 fieldName = PlayerName
+updateIntervalMs = 5000
 


### PR DESCRIPTION
This changes the app to batch up multiple user entries into a single API call to AirTable to resolve #1.

By default, entries will be batched up and pushed into AirTable every 5 seconds (configurable in INI file).  If there are multiple users in one interval, all users will be inserted as a single row where the value will be a comma-separated list of all usernames in that interval/batch.